### PR TITLE
default.nix: Add default value for pkgs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs }:
+{ pkgs ? (import <nixpkgs> {}) }:
 let mkGhc = v@{ncursesVersion ? "6", ...}: pkgs.callPackage ./artifact.nix {} { bindistTarball = (mkTarball v); inherit ncursesVersion;};
     hashes = builtins.fromJSON (builtins.readFile ./hashes.json);
     mkTarball = { url, hash, ...}: pkgs.fetchurl { url = url;


### PR DESCRIPTION
Allowing convenient use with `nix run`.