### PR TITLE
Keep the LD_LIBRARY_PATH in installCheckPhase

### DIFF
--- a/artifact.nix
+++ b/artifact.nix
@@ -169,7 +169,6 @@ stdenv.mkDerivation rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    unset ${libEnvVar}
     # Sanity check, can ghc create executables?
     cd $TMP
     mkdir test-ghc; cd test-ghc


### PR DESCRIPTION
Instantiating a current version of `wip/ghc-debug` (with `ghc-debug`'s `simple-shell.nix`), I got this error:

```
...
running install tests
[1 of 1] Compiling Main             ( main.hs, main.o, main.dyn_o )

<no location info>: warning: [-Wmissed-extra-shared-lib]
    libgmp.so: cannot open shared object file: No such file or directory
    It's OK if you don't want to use symbols from it directly.
    (the package DLL is loaded by the system linker
     which manages dependencies by itself).
Linking main ...
/nix/store/nyhj00w339gk2gaj3faz70gjrnbmam8v-binutils-2.31.1/bin/ld: cannot find -lgmp
collect2: error: ld returned 1 exit status
`gcc' failed in phase `Linker'. (Exit code: 1)
builder for '/nix/store/knlslflki6l5k40l3vx6v2nrbnwdd6dl-ghc-8.11.0.20200725.drv' failed with exit code 1
error: build of '/nix/store/knlslflki6l5k40l3vx6v2nrbnwdd6dl-ghc-8.11.0.20200725.drv' failed
```

This PR keeps the LD_LIBRARY_PATH (including `gmp`) which fixes this error.